### PR TITLE
为 OpenWrt Makefile 添加内核模块依赖

### DIFF
--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -28,7 +28,7 @@ define Package/ua3f
 	SUBMENU:=Web Servers/Proxies
 	TITLE:=Advanced HTTP Rewriting Proxy
 	URL:=https://github.com/SunBK201/UA3F
-	DEPENDS:=$(GO_ARCH_DEPENDS) +luci-compat +ipset +iptables +iptables-mod-tproxy +iptables-mod-extra +iptables-mod-ipopt +iptables-mod-nfqueue +iptables-mod-conntrack-extra +kmod-nf-conntrack-netlink
+	DEPENDS:=$(GO_ARCH_DEPENDS) +luci-compat +ipset +iptables +iptables-mod-tproxy +iptables-mod-extra +iptables-mod-ipopt +iptables-mod-nfqueue +iptables-mod-conntrack-extra +kmod-nf-conntrack-netlink +kmod-nft-queue +kmod-nft-tproxy
 endef
 
 define Package/ua3f/description


### PR DESCRIPTION
添加依赖 `kmod-nft-queue` 和 `kmod-nft-tproxy`，方便自行构建 OpenWrt，减少需要手动选择的项目

此外，我还有一个疑问，UA3F v3.2.0 中添加的 eBPF 相关新功能是否引入了什么额外的依赖呢？